### PR TITLE
Updated API documentation with examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,15 @@
 const fs = require("fs");
 const cloneDeep = require("lodash.clonedeep");
 
-const dfsScrubAws = obj => {
+const dfsScrubKey = (obj, unwantedKey) => {
   Object.keys(obj).map(k => {
-    if (k.startsWith("x-amazon")) {
+    if (k.startsWith(unwantedKey)) {
       delete obj[k];
       return;
     }
 
     if (typeof obj[k] === "object") {
-      dfsScrubAws(obj[k])
+      dfsScrubKey(obj[k], unwantedKey)
     }
   });
 };
@@ -29,7 +29,7 @@ class Gatefold {
   setSwaggerRouteResponse(swaggerObject) {
     let publicSwagger = cloneDeep(swaggerObject);
 
-    dfsScrubAws(publicSwagger);
+    dfsScrubKey(publicSwagger, "x-amazon-apigateway");
     delete publicSwagger.paths["/{id}/proxied"];
     delete publicSwagger.paths["/not-found"];
 
@@ -57,8 +57,9 @@ class Gatefold {
     this.setSwaggerRouteResponse(materialization);
 
     if (scrubAws) {
-      dfsScrubAws(materialization);
+      dfsScrubKey(materialization, "x-amazon-apigateway");
     }
+    dfsScrubKey(materialization, "example");
 
     return materialization;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatefold",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -371,6 +371,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.6",
   "description": "The compact URL shortener. Developed at Cimpress.",
   "main": "index.js",
-  "scripts": {
-  },
+  "scripts": {},
   "bin": {
     "gatefold": "./bin/gatefold.js"
   },
@@ -33,6 +32,7 @@
   "dependencies": {
     "aws-sdk": "^2.226.1",
     "cfn": "^1.6.0",
-    "commander": "^2.15.1"
+    "commander": "^2.15.1",
+    "lodash.clonedeep": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatefold",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "The compact URL shortener. Developed at Cimpress.",
   "main": "index.js",
   "scripts": {

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,7 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "2018-04-21T20:19:38Z",
+    "description": "A simple service that provide URL shortening capabilities through the $GATEFOLD_DOMAIN domain. \n\n A longer URL can be shortened to the following form: https://$GATEFOLD_DOMAIN/[uniqueId]. When accessed, this short URL will automatically redirect to the original using a standard HTTP 302 response with a properly set Location header.\n\nHappy shortening!",
+    "version": "1.0.7",
     "title": "Gatefold"
   },
   "host": "$GATEFOLD_DOMAIN",
@@ -17,7 +18,7 @@
         "produces": [
           "application/json"
         ],
-        "description": "Request a shortened URL.",
+        "summary": "Request a short URL within the $GATEFOLD_DOMAIN domain.",
         "parameters": [
           {
             "in": "body",
@@ -27,10 +28,10 @@
               "$ref": "#/definitions/PostRequest"
             }
           }
-        ],
+        ], 
         "responses": {
           "201": {
-            "description": "201 response",
+            "description": "Shortened version created successfully",
             "schema": {
               "$ref": "#/definitions/PostPutResponse"
             },
@@ -44,7 +45,7 @@
             }
           },
           "500": {
-            "description": "500 response",
+            "description": "Internal server error",
             "headers": {
               "Access-Control-Allow-Origin": {
                 "type": "string"
@@ -52,7 +53,7 @@
             }
           },
           "503": {
-            "description": "503 response",
+            "description": "Service temporarily unavailable",
             "headers": {
               "Access-Control-Allow-Origin": {
                 "type": "string"
@@ -149,7 +150,7 @@
         "produces": [
           "application/json"
         ],
-        "description": "Check if the service is live.",
+        "description": "Provide a healthcheck interface.",
         "responses": {
           "200": {
             "description": "200 response",
@@ -306,7 +307,7 @@
         "produces": [
           "application/json"
         ],
-        "description": "Resolve a shortened URL.",
+        "summary": "Retrieve the long URL associated with the id. This endpoint returns a HTTP 302 response with a Location header containing the long URL.",
         "parameters": [
           {
             "name": "id",
@@ -317,9 +318,10 @@
         ],
         "responses": {
           "302": {
-            "description": "302 response",
+            "description": "Redirection to the original URL",
             "headers": {
               "Location": {
+                "description": "Location of the original resource",
                 "type": "string"
               }
             }
@@ -353,9 +355,11 @@
         "produces": [
           "application/json"
         ],
+        "summary": "Updates the URL hidden behind the specified ID and refreshes the TTL of the ID, meaning that the short URL will continue to be available for a longer period of time.",
         "parameters": [
           {
             "name": "id",
+            "description": "An unique ID identifying the short URL to update",
             "in": "path",
             "required": true,
             "type": "string"
@@ -371,7 +375,7 @@
         ],
         "responses": {
           "200": {
-            "description": "200 response",
+            "description": "Short URL successfully updated",
             "schema": {
               "$ref": "#/definitions/PostPutResponse"
             },
@@ -569,13 +573,20 @@
       "type": "object",
       "properties": {
         "longUrl": {
-          "type": "string"
+          "type": "string",
+          "description": "The long URL which the short URL will redirect to.",
+          "example": "https://www.example.org"
         },
         "shortUrl": {
-          "type": "string"
+          "type": "string",
+          "description": "The short URL that would automatically redirect to the configured long URL.",
+          "example": "https://$GATEFOLD_DOMAIN/ae7d2f3e"
         },
         "token": {
-          "type": "string"
+          "type": "string",
+          "description": "A token that can be used to update the long URL for the generated short URL at later stage.",
+          "example": "ae7d8ca0-8533-11e8-8eba-2f3e608cc07e"
+
         }
       },
       "title": "PostPutRequest"
@@ -587,7 +598,9 @@
       ],
       "properties": {
         "longUrl": {
-          "type": "string"
+          "type": "string",
+          "description": "The long URL to shorten",
+          "example": "https://www.example.org"
         }
       },
       "title": "PostRequest"
@@ -600,10 +613,14 @@
       ],
       "properties": {
         "longUrl": {
-          "type": "string"
+          "type": "string",
+          "description": "A (new) URL to use for the specified short URL",
+          "example": "https://www.example.org"
         },
         "token": {
-          "type": "string"
+          "type": "string",
+          "description": "The token that was generated when the short URL was initially created.",
+          "example": "ae7d8ca0-8533-11e8-8eba-2f3e608cc07e"
         }
       },
       "title": "PutRequest"

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -141,6 +141,100 @@
         }
       }
     },
+    "/swagger": {
+      "get": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "description": "Produces the Gatefold API definition.",
+        "responses": {
+          "200": {
+            "description": "OpenAPI 2.0 (Swagger) Gatefold API definition",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "type": "string"
+              },
+              "Access-Control-Allow-Methods": {
+                "type": "string"
+              },
+              "Access-Control-Allow-Headers": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'"
+              },
+              "responseTemplates": {
+                "application/json": ""
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_match",
+          "type": "mock"
+        }
+      },
+      "options": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "$ref": "#/definitions/Empty"
+            },
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "type": "string"
+              },
+              "Access-Control-Allow-Methods": {
+                "type": "string"
+              },
+              "Access-Control-Allow-Headers": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Methods": "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Amz-Date,X-Api-Key,X-Amz-Security-Token'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'"
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_match",
+          "type": "mock"
+        }
+      }
+    },
     "/livecheck": {
       "get": {
         "consumes": [
@@ -443,6 +537,14 @@
         "produces": [
           "application/json"
         ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
         "responses": {
           "200": {
             "description": "200 response",
@@ -525,6 +627,14 @@
       "options": {
         "produces": [
           "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
Closes #5 
~~Appears to work with AWS API Gateway without any changes.~~

UPDATE: API Gateway does not accept the "example" field. `index.js` has been modified to scrub the key from the Swagger imported by API Gateway, but it preserves those keys for the publicly available Swagger.