### PR TITLE
Accomodate custom Swagger definition modifications with new para

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatefold",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatefold",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "The compact URL shortener. Developed at Cimpress.",
   "main": "index.js",
   "scripts": {},

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "A simple service that provide URL shortening capabilities through the $GATEFOLD_DOMAIN domain. \n\n A longer URL can be shortened to the following form: https://$GATEFOLD_DOMAIN/[uniqueId]. When accessed, this short URL will automatically redirect to the original using a standard HTTP 302 response with a properly set Location header.\n\nHappy shortening!",
-    "version": "1.0.8",
+    "version": "$GATEFOLD_VERSION",
     "title": "Gatefold"
   },
   "host": "$GATEFOLD_DOMAIN",


### PR DESCRIPTION
Closes #4 
It is now possible to specify an additional parameter:
```
-x --external-swagger-transform <file>
```

If the parameter is specified, Gatefold will load the file with require() and expect the exports of the file to be a function. The function is called with the public Swagger API **object** and its return value overwrites the public Swagger API object.